### PR TITLE
feat(Requesting): Detect type of request error and retry depending on…

### DIFF
--- a/lib/nextbus.js
+++ b/lib/nextbus.js
@@ -14,12 +14,16 @@ var API = function(agencyId, timeout) {
 }
 
 API.prototype._send = function(command, params, callback) {
-  
-  var query = util.clone(params)
+
+  var numRequests = 0,
+    retryDelay = 1000,
+    maxRequests = 3,
+    query = util.clone(params),
+    timeout = this.timeout
+
   query.command = command
   query.a = this.agencyId
-  debug('initiate request for ' + command)
-  debug(query)
+  debug('initiate API call for ' + command)
 
   var handleParseResult = function(err, result) {
     if(err) {
@@ -51,26 +55,46 @@ API.prototype._send = function(command, params, callback) {
     } else {
       
       if(!err) {
-        err = new Error('Received non-200 response from server: ' + response.statusCode)
-      }
-
-      // error encountered
-      if(err.code === 'ETIMEDOUT') {
-        debug('Connection timeout')
-      } else if(err.code === 'ESOCKETTIMEDOUT') {
-        debug('Response read timeout')
+        debug('Received non-200 response from server: ' + response.statusCode)
+      } else {
+        // http error encountered
+        if(err.code === 'ETIMEDOUT') {
+          debug('Connection timeout')
+        } else if(err.code === 'ESOCKETTIMEDOUT') {
+          debug('Response read timeout')
+        } else {
+          debug(err)
+        }
       }
       
-      callback(err)
+      setTimeout(makeRequest, retryDelay)
+
+      retryDelay *= 2
     }
   }
 
-  request({
-    url: nextbusURL,
-    qs: query,
-    qsStringifyOptions: qsStringifyOptions,
-    timeout: this.timeout
-  }, handleResponse)
+  var makeRequest = function() {
+ 
+    debug('request #' + numRequests)
+    debug(command, Object.keys(query))
+
+    numRequests += 1
+
+    if(numRequests > maxRequests) {
+      var err = new Error('Maximum request retries exceeded')
+      debug(err)
+      return callback(err)
+    }
+
+    request({
+      url: nextbusURL,
+      qs: query,
+      qsStringifyOptions: qsStringifyOptions,
+      timeout: timeout
+    }, handleResponse)
+  }
+
+  makeRequest()
 
 }
 

--- a/lib/tripUpdates.js
+++ b/lib/tripUpdates.js
@@ -24,7 +24,6 @@ module.exports = function(nextbus, cacheExpiration, callback) {
 
   var msg = util.makeMessageTemplate(),
     tripUpdates = {},
-    numPredictionRetries = 0,
     routeStopPairRequestQueue
 
   var resetRouteStopPairRequestQueue = function() {
@@ -43,12 +42,11 @@ module.exports = function(nextbus, cacheExpiration, callback) {
 
       if(err) {
         debug('getMultiPredictions err', err)
-        if(numPredictionRetries === 0) {
-          numPredictionRetries++
+        if(err.message && err.message.indexOf('cannot determine which stop to provide data for') > -1) {
+          debug('potential schedule change detected, refresh cache')
           resetRouteStopPairRequestQueue()
           return refetchAllRoutes(callback)
         } else {
-          var err = new Error('Maximum prediction retries exceeded')
           return callback(err)
         }
       }


### PR DESCRIPTION
… circumstance.

Retry up to 3 times in case of non-200 http status response, or connection or read timeout.  Only

refresh route stop cache in case of specific error response.
